### PR TITLE
Format datetimes as second-granularity RFC-3339

### DIFF
--- a/squareup/src/models/date_time.rs
+++ b/squareup/src/models/date_time.rs
@@ -67,7 +67,7 @@ impl<'de> Deserialize<'de> for DateTime {
 
 impl Display for DateTime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.inner, f)
+        std::fmt::Display::fmt(&self.inner.to_rfc3339_opts(chrono::SecondsFormat::Millis, true), f)
     }
 }
 


### PR DESCRIPTION
I'm not sure if the original code used rfc-3339, but Square was rejecting it saying (listing payments):

```
begin_time must be in RFC 3339 format
```

I tried limiting the seconds to milliseconds and it worked (the examples in their docs also don't have micro/nanosecond precision).  AFAICT all the places `DateTime` used required rfc-3339 per the docs, so I don't expect this would be incorrect anywhere.