### PR TITLE
custom_attribute and related APIs

### DIFF
--- a/squareup/src/api/customer_custom_attributes_api.rs
+++ b/squareup/src/api/customer_custom_attributes_api.rs
@@ -156,7 +156,7 @@ impl CustomerCustomAttributesApi {
         &self,
         request: &BulkUpsertCustomerCustomAttributesRequest,
     ) -> Result<BulkUpsertCustomerCustomAttributesResponse, SquareApiError> {
-        let url = format!("{}//custom-attributes/bulk-upsert", self.url());
+        let url = format!("{}/custom-attributes/bulk-upsert", self.url());
         let response = self.http_client.post(&url, request).await?;
 
         response.deserialize().await

--- a/squareup/src/models/bulk_upsert_customer_custom_attributes_request.rs
+++ b/squareup/src/models/bulk_upsert_customer_custom_attributes_request.rs
@@ -1,5 +1,7 @@
 //! Model struct for BulkUpsertCustomerCustomAttributesRequest type
 
+use std::collections::HashMap;
+
 use super::BulkUpsertCustomerCustomAttributesRequestCustomerCustomAttributeUpsertRequest;
 use serde::{Deserialize, Serialize};
 
@@ -7,5 +9,5 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BulkUpsertCustomerCustomAttributesRequest {
     /// A list of 1 to 25 individual upsert requests.
-    pub values: Vec<BulkUpsertCustomerCustomAttributesRequestCustomerCustomAttributeUpsertRequest>,
+    pub values: HashMap<String, BulkUpsertCustomerCustomAttributesRequestCustomerCustomAttributeUpsertRequest>,
 }

--- a/squareup/src/models/bulk_upsert_customer_custom_attributes_response.rs
+++ b/squareup/src/models/bulk_upsert_customer_custom_attributes_response.rs
@@ -1,5 +1,7 @@
 //! Model struct for BulkUpsertCustomerCustomAttributesResponse type
 
+use std::collections::HashMap;
+
 use super::BulkUpsertCustomerCustomAttributesResponseCustomerCustomAttributeUpsertResponse;
 use crate::models::errors::Error;
 use serde::{Deserialize, Serialize};
@@ -9,7 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct BulkUpsertCustomerCustomAttributesResponse {
     /// A list of responses that correspond to individual upsert requests.
     pub values:
-        Vec<BulkUpsertCustomerCustomAttributesResponseCustomerCustomAttributeUpsertResponse>,
+        HashMap<String, BulkUpsertCustomerCustomAttributesResponseCustomerCustomAttributeUpsertResponse>,
     /// Any errors that occurred during the request.
     pub errors: Option<Vec<Error>>,
 }

--- a/squareup/src/models/custom_attribute.rs
+++ b/squareup/src/models/custom_attribute.rs
@@ -22,15 +22,20 @@ pub struct CustomAttribute {
     /// **Read only**. The current version of the custom attribute. This field is incremented when the custom attribute
     /// is changed. When updating an existing custom attribute value, you can provide this field and specify the current
     /// version of the custom attribute to enable optimistic concurrency.
+    #[serde(skip_serializing_if = "Option::is_none")] 
     pub version: Option<i32>,
     /// **Read only**. A copy of the visibility field value for the associated custom attribute definition.
+    #[serde(skip_serializing_if = "Option::is_none")] 
     pub visibility: Option<CustomAttributeDefinitionVisibility>,
     /// **Read only**. A copy of the associated custom attribute definition object. This field is only set
     /// when the optional field is specified on the request.
+    #[serde(skip_serializing_if = "Option::is_none")] 
     pub definition: Option<CustomAttributeDefinition>,
     /// **Read only**. The timestamp that indicates when the custom attribute was created or most recently updated,
     /// in RFC 3339 format.
+    #[serde(skip_serializing_if = "Option::is_none")] 
     pub updated_at: Option<DateTime>,
     /// **Read only**. The timestamp that indicates when the custom attribute was created, in RFC 3339 format.
+    #[serde(skip_serializing_if = "Option::is_none")] 
     pub created_at: Option<DateTime>,
 }


### PR DESCRIPTION
This might need to be two tickets there were three issues:

 1. Some of the fields for custom_attributes and customer_custom_attributes require omission of fields in the submission as setting them to null would mean something that isn't allowed.
 2. A URL had a double / leading it and caused an resource error at square.
 3. A bulk operation requiring a HashMap of items was using a Vec of those items.