### PR TITLE
Leverage serde_error_to_path for developer-friendly error messages.

### DIFF
--- a/squareup/Cargo.toml
+++ b/squareup/Cargo.toml
@@ -26,6 +26,7 @@ package_info_derive = "0.1.0"
 rustc_version_runtime = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_path_to_error = "0.1.17"
 chrono-tz = { version = "0.10.0", features = ["filter-by-regex"] }
 
 [features]


### PR DESCRIPTION
This change will tell you where the JSON document failed to decode structurally which is much more useful/actionable than a byte offset.