### PR TITLE
(bug) Name the field after the struct (invoice, not refund)

### DIFF
--- a/squareup/src/models/get_invoice_response.rs
+++ b/squareup/src/models/get_invoice_response.rs
@@ -8,7 +8,7 @@ use super::{Invoice, errors::Error};
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 pub struct GetInvoiceResponse {
     /// The invoice requested.
-    pub refund: Option<Invoice>,
+    pub invoice: Option<Invoice>,
     /// Information about errors encountered during the request.
     pub errors: Option<Vec<Error>>,
 }


### PR DESCRIPTION
I found a small bug while using the Invoices API. Probably forgot to reformat a copy-pasta, but this will fix it.