### PR TITLE
(feat) enable verbose logging if `RUST_LOG` permits

### DIFF
--- a/squareup/src/http/client/http_client.rs
+++ b/squareup/src/http/client/http_client.rs
@@ -31,7 +31,8 @@ impl HttpClient {
         let client_builder = reqwest::ClientBuilder::new()
             .timeout(Duration::from_secs(config.timeout.into()))
             .user_agent(&config.user_agent)
-            .default_headers((&config.default_headers).try_into()?);
+            .default_headers((&config.default_headers).try_into()?)
+            .connection_verbose(true);
 
         #[cfg(feature = "native-tls")]
         let client_builder = client_builder;


### PR DESCRIPTION
This might not be the best method to do this, but in practice this works pretty well.

**The need**

I need/want to see what was being send to the Square backends, but that was pretty opaque without being able to configure the `reqwest` client to do so. I turned up `RUST_LOG=trace` and got a ton of stuff, but none of it was the body of the request being sent out.

**The solution**

Enable `connection_verbose(true)` on the `ClientBuilder`. This doesn't actually print out anything unless you set `RUST_LOG=trace` or you can selectively enable that output with something like `RUST_LOG="$RUST_LOG,reqwest::connect=trace"` and only get `trace` output for that module.

**My rationale**

I could have added another variable into the `HttpClientConfiguration` struct, and that would have promptly broken API compatibility with all of the other (literally _dozens_) of uses. I could have added a default value and a method, sure... Or you could just take the hard coded value and not run at `trace` logging and now it's a one-line change.

**In the end**

I'm totally open to this being improved in a meaningful and less hard-coded manner but my effort-reward balance scale said this was a good choice.