### PR TITLE
Invoice struct fixes

### DIFF
--- a/squareup/src/models/invoice.rs
+++ b/squareup/src/models/invoice.rs
@@ -15,9 +15,11 @@ use super::{
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Invoice {
     /// **Read only** The Square-assigned ID of the invoice.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    /// The Square-assigned version number, which is incremented each time an update is committed to
-    /// the invoice.
+    /// **Read only** The Square-assigned version number, which is incremented each time an update
+    /// is committed to the invoice.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<i32>,
     /// The ID of the location that this invoice is associated with.
     ///
@@ -25,6 +27,7 @@ pub struct Invoice {
     /// associated order.
     ///
     /// Min Length: 1, Max Length: 255
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub location_id: Option<String>,
     /// The ID of the [Order] for which the invoice is created. This field is required when creating
     /// an invoice, and the order must be in the `OPEN` state.
@@ -39,6 +42,7 @@ pub struct Invoice {
     /// used by Square to deliver the invoice.
     ///
     /// This field is required to publish an invoice, and it must specify the `customer_id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub primary_recipient: Option<InvoiceRecipient>,
     /// The payment schedule for the invoice, represented by one or more payment requests that
     /// define payment settings, such as amount due and due date. An invoice supports the following
@@ -58,6 +62,7 @@ pub struct Invoice {
     /// subscription](https://developer.squareup.com/docs/invoices-api/overview#invoices-plus-subscription).
     ///
     /// Min Length: 1, Max Length: 13
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_requests: Option<Vec<InvoicePaymentRequest>>,
     /// The delivery method that Square uses to send the invoice, reminders, and receipts to the
     /// customer. After the invoice is published, Square processes the invoice based on the delivery
@@ -71,6 +76,7 @@ pub struct Invoice {
     ///   `automatic_payment_source` field of the payment request is also required.
     /// - The deprecated `request_method` field of the payment request. Note that `invoice` objects
     ///   returned in responses do not include `request_method`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delivery_method: Option<InvoiceDeliveryMethod>,
     /// A user-friendly invoice number that is displayed on the invoice. The value is unique within
     /// a location. If not provided when creating an invoice, Square assigns a value. It increments
@@ -78,20 +84,24 @@ pub struct Invoice {
     /// 0000002).
     ///
     /// Min Length: 1, Max Length: 191
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub invoice_number: Option<String>,
     /// The title of the invoice, which is displayed on the invoice.
     ///
     /// Min Length: 1, Max Length: 255
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The description of the invoice, which is displayed on the invoice.
     ///
     /// Min Length: 1, Max Length: 65536
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// The timestamp when the invoice is scheduled for processing, in RFC 3339 format. After the
     /// invoice is published, Square processes the invoice on the specified date, according to the
     /// delivery method and payment request settings.
     ///
     /// If the field is not set, Square processes the invoice immediately after it is published.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scheduled_at: Option<DateTime>,
     /// **Read only** A temporary link to the Square-hosted payment page where the customer can pay
     /// the invoice. If the link expires, customers can provide the email address or phone number
@@ -99,25 +109,32 @@ pub struct Invoice {
     ///
     /// This field is added after the invoice is published and reaches the scheduled date (if one
     /// is defined).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub public_url: Option<String>,
     /// Read only The current amount due for the invoice. In addition to the amount due on the next
     /// payment request, this includes any overdue payment amounts.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_payment_amount_money: Option<Money>,
     /// **Read only** The status of the invoice.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<InvoiceStatus>,
-    /// Read only The time zone used to interpret calendar dates on the invoice, such as `due_date`.
+    /// **Read only** The time zone used to interpret calendar dates on the invoice, such as `due_date`.
     /// When an invoice is created, this field is set to the `timezone` specified for the seller
     /// location. The value cannot be changed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<Timezone>,
     /// **Read only** The timestamp when the invoice was created, in RFC 3339 format.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime>,
     /// **Read only** The timestamp when the invoice was last updated, in RFC 3339 format.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<DateTime>,
     /// The payment methods that customers can use to pay the invoice on the Square-hosted invoice
     /// page. This setting is independent of any automatic payment requests for the invoice.
     ///
     /// This field is required when creating an invoice and must set at least one payment method to
     /// `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_payment_methods: Option<InvoiceAcceptedPaymentMethods>,
     /// Additional seller-defined fields that are displayed on the invoice. For more information,
     /// see [Custom
@@ -129,13 +146,16 @@ pub struct Invoice {
     /// Max: 2 custom fields
     ///
     /// Max Length: 2
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_fields: Option<Vec<InvoiceCustomField>>,
     /// **Read only** The ID of the
     /// [subscription](https://developer.squareup.com/reference/square/objects/Subscription)
     /// associated with the invoice. This field is present only on subscription billing invoices.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_id: Option<String>,
     /// The date of the sale or the date that the service is rendered, in `YYYY-MM-DD` format. This
     /// field can be used to specify a past or future date which is displayed on the invoice.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sale_or_service_date: Option<String>,
     /// **France only**. The payment terms and conditions that are displayed on the invoice. For
     /// more information, see [Payment
@@ -146,18 +166,22 @@ pub struct Invoice {
     /// detail if this field is included in `CreateInvoice` or `UpdateInvoice` requests.
     ///
     /// Min Length: 1, Max Length: 2000
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_conditions: Option<String>,
     /// Indicates whether to allow a customer to save a credit or debit card as a card on file or a
     /// bank transfer as a bank account on file. If `true`, Square displays a **Save my card on
     /// file** or **Save my bank on file** checkbox on the invoice payment page. Stored payment
     /// information can be used for future automatic payments. The default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub store_payment_method_enabled: Option<bool>,
-    /// Read only Metadata about the attachments on the invoice. Invoice attachments are managed using the
-    /// CreateInvoiceAttachment and DeleteInvoiceAttachment endpoints.
+    /// **Read only** Metadata about the attachments on the invoice. Invoice attachments are managed
+    /// using the CreateInvoiceAttachment and DeleteInvoiceAttachment endpoints.
     /// Max Length 10
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<InvoiceAttachment>>,
     /// **Read only** The ID of the team member who created the invoice. This field is present
     /// only on invoices created in the Square Dashboard or Square Invoices app by a logged-in
     /// team member.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub creator_team_member_id: Option<String>,
 }

--- a/squareup/src/models/invoice_accepted_payment_methods.rs
+++ b/squareup/src/models/invoice_accepted_payment_methods.rs
@@ -7,13 +7,16 @@ use serde::{Deserialize, Serialize};
 pub struct InvoiceAcceptedPaymentMethods {
     /// Indicates whether credit card or debit card payments are accepted. The default value is
     /// `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub card: Option<bool>,
     /// Indicates whether Square gift card payments are accepted. The default value is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub square_gift_card: Option<bool>,
     /// Indicates whether bank transfer payments are accepted. The default value is `false`.
     ///
     /// This option is allowed only for invoices that have a single payment request of type
     /// `BALANCE`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bank_account: Option<bool>,
     /// Indicates whether Afterpay (also known as Clearpay) payments are accepted. The default value is false.
     ///
@@ -22,9 +25,11 @@ pub struct InvoiceAcceptedPaymentMethods {
     /// is in a country where Afterpay invoice payments are supported. As a best practice, consider enabling
     /// an additional payment method when allowing buy_now_pay_later payments. For more information,
     /// including detailed requirements and processing limits, see Buy Now Pay Later payments with Afterpay.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub buy_now_pay_later: Option<bool>,
     /// Indicates whether Cash App payments are accepted. The default value is false.
     ///
     /// This payment method is supported only for seller locations in the United States.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cash_app_pay: Option<bool>,
 }

--- a/squareup/src/models/invoice_payment_request.rs
+++ b/squareup/src/models/invoice_payment_request.rs
@@ -20,9 +20,11 @@ pub struct InvoicePaymentRequest {
     /// The Square-generated ID of the payment request in an [Invoice].
     ///
     /// Min Length: 1, Max Length: 255
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<String>,
     /// Identifies the payment request type. This type defines how the payment request amount is
     /// determined. This field is required to create a payment request.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub request_type: Option<InvoiceRequestType>,
     /// The due date (in the invoice's time zone) for the payment request, in `YYYY-MM-DD` format.
     /// This field is required to create a payment request. If an `automatic_payment_source` is
@@ -35,6 +37,7 @@ pub struct InvoicePaymentRequest {
     /// If the payment request specifies `DEPOSIT` or `INSTALLMENT` as the `request_type`, this
     /// indicates the request amount. You cannot specify this when `request_type` is `BALANCE` or
     /// when the payment request includes the `percentage_requested` field.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fixed_amount_requested_money: Option<Money>,
     /// Specifies the amount for the payment request in percentage:
     ///
@@ -46,16 +49,19 @@ pub struct InvoicePaymentRequest {
     ///
     /// You cannot specify this when the payment `request_type` is `BALANCE` or when the payment
     /// request specifies the `fixed_amount_requested_money` field.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub percentage_requested: Option<String>,
     /// If set to true, the Square-hosted invoice page (the `public_url` field of the invoice)
     /// provides a place for the customer to pay a tip.
     ///
     /// This field is allowed only on the final payment request and the payment `request_type` must
     /// be `BALANCE` or `INSTALLMENT`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tipping_enabled: Option<bool>,
     /// The payment method for an automatic payment.
     ///
     /// The default value is `NONE`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub automatic_payment_source: Option<InvoiceAutomaticPaymentSource>,
     /// The ID of the credit or debit card on file to charge for the payment request. To get the
     /// cards on file for a customer, call
@@ -63,20 +69,25 @@ pub struct InvoicePaymentRequest {
     /// include the `customer_id` of the invoice recipient.
     ///
     /// Min Length: 1, Max Length: 255
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub card_id: Option<String>,
     /// A list of one or more reminders to send for the payment request.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reminders: Option<Vec<InvoicePaymentReminder>>,
     /// **Read only** The amount of the payment request, computed using the order amount and
     /// information from the various payment request fields (`request_type`,
     /// `fixed_amount_requested_money`, and `percentage_requested`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub computed_amount_money: Option<Money>,
     /// **Read only** The amount of money already paid for the specific payment request. This amount
     /// might include a rounding adjustment if the most recent invoice payment was in cash in a
     /// currency that rounds cash payments (such as, `CAD` or `AUD`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub total_completed_amount_money: Option<Money>,
     /// **Read only** If the most recent payment was a cash payment in a currency that rounds cash
     /// payments (such as, `CAD` or `AUD`) and the payment is rounded from `computed_amount_money`
     /// in the payment request, then this field specifies the rounding adjustment applied. This
     /// amount might be negative.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rounding_adjustment_included_money: Option<Money>,
 }

--- a/squareup/src/models/invoice_payment_request.rs
+++ b/squareup/src/models/invoice_payment_request.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::{
-    DateTime, InvoicePaymentReminder, Money,
+    InvoicePaymentReminder, Money,
     enums::{InvoiceAutomaticPaymentSource, InvoiceRequestMethod, InvoiceRequestType},
 };
 
@@ -36,14 +36,14 @@ pub struct InvoicePaymentRequest {
     /// Identifies the payment request type. This type defines how the payment request amount is
     /// determined. This field is required to create a payment request.
     pub request_type: Option<InvoiceRequestType>,
-    ///The due date (in the invoice's time zone) for the payment request, in `YYYY-MM-DD` format.
+    /// The due date (in the invoice's time zone) for the payment request, in `YYYY-MM-DD` format.
     /// This field is required to create a payment request. If an `automatic_payment_source` is
     /// defined for the request, Square charges the payment source on this date.
     ///
     /// After this date, the invoice becomes overdue. For example, a payment `due_date` of
     /// 2021-03-09 with a `timezone` of America/Los_Angeles becomes overdue at midnight on March 9
     /// in America/Los_Angeles (which equals a UTC timestamp of 2021-03-10T08:00:00Z).
-    pub due_date: Option<DateTime>,
+    pub due_date: Option<chrono::NaiveDate>,
     /// If the payment request specifies `DEPOSIT` or `INSTALLMENT` as the `request_type`, this
     /// indicates the request amount. You cannot specify this when `request_type` is `BALANCE` or
     /// when the payment request includes the `percentage_requested` field.

--- a/squareup/src/models/invoice_payment_request.rs
+++ b/squareup/src/models/invoice_payment_request.rs
@@ -21,18 +21,6 @@ pub struct InvoicePaymentRequest {
     ///
     /// Min Length: 1, Max Length: 255
     pub uid: Option<String>,
-    /// Indicates how Square processes the payment request. DEPRECATED at version 2021-01-21.
-    /// Replaced by the `Invoice.delivery_method` and
-    /// `InvoicePaymentRequest.automatic_payment_source` fields.
-    ///
-    /// One of the following is required when creating an invoice:
-    ///
-    /// (Recommended) The `delivery_method` field of the invoice. To configure an automatic payment,
-    /// the `automatic_payment_source` field of the payment request is also required.
-    /// This `request_method` field. Note that `invoice` objects returned in responses do not
-    /// include `request_method`.
-    #[deprecated]
-    pub request_method: Option<InvoiceRequestMethod>,
     /// Identifies the payment request type. This type defines how the payment request amount is
     /// determined. This field is required to create a payment request.
     pub request_type: Option<InvoiceRequestType>,

--- a/squareup/src/models/invoice_recipient.rs
+++ b/squareup/src/models/invoice_recipient.rs
@@ -21,19 +21,26 @@ pub struct InvoiceRecipient {
     /// Min Length: 1, Max Length: 255
     pub customer_id: Option<String>,
     /// **Read only** The recipient's given (that is, first) name.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub given_name: Option<String>,
     /// **Read only** The recipient's family (that is, last) name.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub family_name: Option<String>,
     /// **Read only** The recipient's email address.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email_address: Option<String>,
     /// **Read only** The recipient's physical address.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<Address>,
     /// **Read only** The recipient's phone number.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub phone_number: Option<String>,
     /// **Read only** The name of the recipient's company.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub company_name: Option<String>,
     /// **Read only** The recipient's tax IDs. The country of the seller account determines whether
     /// this field is available for the customer. For more information, see [Invoice recipient tax
     /// IDs](https://developer.squareup.com/docs/invoices-api/overview#recipient-tax-ids).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_ids: Option<InvoiceRecipientTaxIds>,
 }


### PR DESCRIPTION
**Data format of `due_date`**

The struct uses a `DateTime` to represent a field that is an explicit `Date`. You can't set it to a date-only string because the struct isn't valid and you can't send a date with a time because the square api returns an error on the format of the data.

I changed it to a `chrono::NaiveDate` since there is an explicit `timezone` field to allow for timezone-aware parsing.

**Sending invalid data to Square**

I encountered a lot of issues using the invoices api to create an invoice. The end result is that I had to basically omit all of the values that ended up being a `None`. The commit message has a much more detailed explanation.

It's a bit on the heavy-handed side of things, because once I found the third or fourth field that the square API was complaining about being in the wrong format I went full-bore and removed anything that was square-managed (read-only) or possibly a `None`.

**Deprecated Field in invoice**

I also removed a deprecated field, which might warrant a separate conversation about the policy on deprecation timelines and API expectations. I can definitely remove that commit if needed. The square API deprecated the field almost 5 years ago and the solution is pretty straight-forward, so I don't feel like this will be a great or undue burden on downstream consumers.